### PR TITLE
do not force electron version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,7 +34,6 @@ build() {
     --verbose \
     --single-instance \
     --tray \
-    --electron-version 9.0.2 \
     "${url}"
 }
 


### PR DESCRIPTION
current version uses couple of months old electron build, causing a warning message about using old electron on every startup.