### PR TITLE
Add start-in-tray option

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,7 +34,7 @@ build() {
     --browserwindow-options '{ "webPreferences": { "spellcheck": true } }' \
     --verbose \
     --single-instance \
-    --tray \
+    --tray start-in-tray \
     "${url}"
 }
 


### PR DESCRIPTION
When it's added to autostart it's really annoying to have the window open every time you boot your PC.
Maybe this should be configurable, but I don't know how to do that.