### PR TITLE
inject.js: use @nielstron's version

### DIFF
--- a/whatsapp-nativefier-inject.js
+++ b/whatsapp-nativefier-inject.js
@@ -1,7 +1,23 @@
-if ('serviceWorker' in navigator) {
-    caches.keys().then(function (cacheNames) {
-        cacheNames.forEach(function (cacheName) {
-            caches.delete(cacheName);
-        });
+// Originally from: https://github.com/nielstron/ubuntu.whatsapp-nativefier/blob/master/whatsapp-nativefier-inject.js
+//
+// Copyright 2021 Niels Mündler
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+function recheck () {
+    navigator.serviceWorker.getRegistrations().then((registrations) => {
+        for(registration of registrations){
+             registration.unregister();
+        }
+        if (document.querySelector("body[class='page-version']")) {
+            console.log("reload");
+            document.location.reload();
+         }
     });
+    setTimeout(recheck, 5000); // callback
 }
+recheck();


### PR DESCRIPTION
Based on https://github.com/nativefier/nativefier/issues/719, this is the most reliable version.

Note: Whatsapp works for me even with the old version but since the community seems to agree @nielstron's inject.js is the best, let's unify the code across distros.